### PR TITLE
Optimize rendering & dispose(s)

### DIFF
--- a/packages/rad/lib/rad.dart
+++ b/packages/rad/lib/rad.dart
@@ -42,8 +42,9 @@ export 'src/core/common/enums.dart' show WrapType;
 export 'src/core/common/enums.dart' show SpellCheckType;
 export 'src/core/common/enums.dart' show ScopeType;
 
-export 'src/core/common/enums.dart' show DomEventType;
 export 'src/core/common/enums.dart' show DomTagType;
+export 'src/core/common/enums.dart' show DomEventType;
+export 'src/core/common/enums.dart' show RenderEventType;
 
 export 'src/core/common/enums.dart' show UpdateType;
 
@@ -80,6 +81,7 @@ export 'src/core/interface/window/abstract.dart' show WindowDelegate;
 export 'src/core/common/objects/key.dart' show Key;
 export 'src/widgets/abstract/widget.dart' show Widget;
 export 'src/core/services/events/emitted_event.dart' show EmittedEvent;
+export 'src/core/common/objects/render_event.dart' show RenderEvent;
 export 'src/core/common/abstract/build_context.dart' show BuildContext;
 export 'src/core/common/abstract/render_element.dart' show RenderElement;
 export 'src/core/common/objects/common_render_elements.dart'

--- a/packages/rad/lib/src/core/common/abstract/render_element.dart
+++ b/packages/rad/lib/src/core/common/abstract/render_element.dart
@@ -404,6 +404,11 @@ abstract class RenderElement implements BuildContext {
 
     _eventListeners = listeners;
 
+    if (_eventListeners.containsKey(RenderEventType.afterUnMountEffect) ||
+        _eventListeners.containsKey(RenderEventType.beforeUnMountEffect)) {
+      _announceUnMountListeners();
+    }
+
     _isEventsRegistered = true;
   }
 
@@ -488,6 +493,33 @@ abstract class RenderElement implements BuildContext {
     if (null != listener) {
       listener(const RenderEvent());
     }
+  }
+
+  /*
+  |--------------------------------------------------------------------------
+  | framework reserved | event announce APIs
+  |--------------------------------------------------------------------------
+  */
+
+  /// Whether this part of tree contains any un-mount event listener.
+  ///
+  /// @nodoc
+  @internal
+  @nonVirtual
+  bool get frameworkContainsUnMountListeners => _containsUnMountListeners;
+  var _containsUnMountListeners = false;
+
+  /// @nodoc
+  @nonVirtual
+  void _announceUnMountListeners() {
+    visitAncestorElements((renderElement) {
+      if (renderElement.frameworkContainsUnMountListeners) {
+        return false;
+      }
+
+      renderElement._containsUnMountListeners = true;
+      return true;
+    });
   }
 
   /*

--- a/packages/rad/lib/src/core/common/abstract/render_element.dart
+++ b/packages/rad/lib/src/core/common/abstract/render_element.dart
@@ -158,6 +158,11 @@ abstract class RenderElement implements BuildContext {
   |--------------------------------------------------------------------------
   */
 
+  /// Register hook.
+  ///
+  @protected
+  void register() {}
+
   /// Render hook.
   ///
   /// This hook gets called exactly once during lifetime of an element. This
@@ -385,6 +390,10 @@ abstract class RenderElement implements BuildContext {
   |--------------------------------------------------------------------------
   */
 
+  /// Whether execution of [RenderElement.register] is pending.
+  ///
+  var _isInRegistrationPhase = true;
+
   /// @nodoc
   @nonVirtual
   @internal
@@ -445,6 +454,16 @@ abstract class RenderElement implements BuildContext {
     if (null != _domNode) {
       _hasDomNode = true;
     }
+  }
+
+  /// @nodoc
+  @internal
+  @nonVirtual
+  void frameworkInitRenderElement() {
+    assert(_isInRegistrationPhase, 'RenderElement already registered');
+
+    register();
+    _isInRegistrationPhase = false;
   }
 
   /// @nodoc

--- a/packages/rad/lib/src/core/common/abstract/render_element.dart
+++ b/packages/rad/lib/src/core/common/abstract/render_element.dart
@@ -404,8 +404,8 @@ abstract class RenderElement implements BuildContext {
 
     _eventListeners = listeners;
 
-    if (_eventListeners.containsKey(RenderEventType.afterUnMountEffect) ||
-        _eventListeners.containsKey(RenderEventType.beforeUnMountEffect)) {
+    if (_eventListeners.containsKey(RenderEventType.didUnMount) ||
+        _eventListeners.containsKey(RenderEventType.willUnMount)) {
       _announceUnMountListeners();
     }
 

--- a/packages/rad/lib/src/core/common/abstract/watchful_render_element.dart
+++ b/packages/rad/lib/src/core/common/abstract/watchful_render_element.dart
@@ -34,10 +34,10 @@ abstract class WatchfulRenderElement extends RenderElement {
   @override
   void register() {
     addRenderEventListeners({
-      RenderEventType.afterRenderEffect: frameworkAfterMount,
-      RenderEventType.afterUpdateEffect: frameworkAfterUpdate,
-      RenderEventType.beforeUnMountEffect: frameworkBeforeUnMount,
-      RenderEventType.afterUnMountEffect: frameworkAfterUnMount,
+      RenderEventType.didRender: frameworkDidRender,
+      RenderEventType.didUpdate: frameworkDidUpdate,
+      RenderEventType.willUnMount: frameworkWillUnMount,
+      RenderEventType.didUnMount: frameworkDidUnMount,
     });
 
     init();
@@ -97,7 +97,7 @@ abstract class WatchfulRenderElement extends RenderElement {
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkAfterMount(RenderEvent event) {
+  void frameworkDidRender(RenderEvent event) {
     assert(!isMounted, 'Widget is already mounted');
 
     _isMounted = true;
@@ -108,21 +108,21 @@ abstract class WatchfulRenderElement extends RenderElement {
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkAfterUpdate(RenderEvent event) {
+  void frameworkDidUpdate(RenderEvent event) {
     afterUpdate();
   }
 
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkBeforeUnMount(RenderEvent event) {
+  void frameworkWillUnMount(RenderEvent event) {
     dispose();
   }
 
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkAfterUnMount(RenderEvent event) {
+  void frameworkDidUnMount(RenderEvent event) {
     assert(isMounted, 'Widget is not mounted yet');
 
     _isMounted = false;

--- a/packages/rad/lib/src/core/common/abstract/watchful_render_element.dart
+++ b/packages/rad/lib/src/core/common/abstract/watchful_render_element.dart
@@ -28,6 +28,13 @@ abstract class WatchfulRenderElement extends RenderElement {
   bool get isMounted => _isMounted;
   bool _isMounted = false;
 
+  /// @nodoc
+  @nonVirtual
+  @override
+  void register() {
+    init();
+  }
+
   /*
   |--------------------------------------------------------------------------
   | lifecycle hooks
@@ -78,13 +85,6 @@ abstract class WatchfulRenderElement extends RenderElement {
   | framework reserved | lifecycle api
   |--------------------------------------------------------------------------
   */
-
-  /// @nodoc
-  @internal
-  @nonVirtual
-  void frameworkInit() {
-    init();
-  }
 
   /// @nodoc
   @internal

--- a/packages/rad/lib/src/core/common/abstract/watchful_render_element.dart
+++ b/packages/rad/lib/src/core/common/abstract/watchful_render_element.dart
@@ -5,13 +5,14 @@
 import 'package:meta/meta.dart';
 
 import 'package:rad/src/core/common/abstract/render_element.dart';
+import 'package:rad/src/core/common/enums.dart';
+import 'package:rad/src/core/common/objects/render_event.dart';
 
-/// Base class for render elements that are watching their position in the tree.
+/// A render element show casing lifecycle events.
 ///
-/// Watchful elements differs from other render elements in that framework
-/// consider them alive in tree and framework will let them know when it
-/// mounts or un-mounts them from tree so that these elements can take
-/// appropriate actions.
+/// This class serves as an example that shows additional functionality
+/// (such as lifecycle events) provided by [RenderElement]s. It can be used
+/// as-it-is as well.
 ///
 abstract class WatchfulRenderElement extends RenderElement {
   WatchfulRenderElement(super.widget, super.parent);
@@ -32,6 +33,13 @@ abstract class WatchfulRenderElement extends RenderElement {
   @nonVirtual
   @override
   void register() {
+    addRenderEventListeners({
+      RenderEventType.afterRenderEffect: frameworkAfterMount,
+      RenderEventType.afterUpdateEffect: frameworkAfterUpdate,
+      RenderEventType.beforeUnMountEffect: frameworkBeforeUnMount,
+      RenderEventType.afterUnMountEffect: frameworkAfterUnMount,
+    });
+
     init();
   }
 
@@ -89,7 +97,7 @@ abstract class WatchfulRenderElement extends RenderElement {
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkAfterMount() {
+  void frameworkAfterMount(RenderEvent event) {
     assert(!isMounted, 'Widget is already mounted');
 
     _isMounted = true;
@@ -100,21 +108,21 @@ abstract class WatchfulRenderElement extends RenderElement {
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkAfterUpdate() {
+  void frameworkAfterUpdate(RenderEvent event) {
     afterUpdate();
   }
 
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkDispose() {
+  void frameworkBeforeUnMount(RenderEvent event) {
     dispose();
   }
 
   /// @nodoc
   @internal
   @nonVirtual
-  void frameworkAfterUnMount() {
+  void frameworkAfterUnMount(RenderEvent event) {
     assert(isMounted, 'Widget is not mounted yet');
 
     _isMounted = false;

--- a/packages/rad/lib/src/core/common/enums.dart
+++ b/packages/rad/lib/src/core/common/enums.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import 'package:rad/src/core/common/abstract/render_element.dart';
 import 'package:rad/src/widgets/gesture_detector.dart';
 
 /// The two cardinal directions in two dimensions.
@@ -403,6 +404,30 @@ enum ReferrerPolicyType {
 
   final String nativeValue;
   const ReferrerPolicyType(this.nativeValue);
+}
+
+/// Type of Render event.
+///
+enum RenderEventType {
+  /// A event that's fired after framework finishes rendering the output
+  /// of [RenderElement.render] to the DOM.
+  ///
+  afterRenderEffect,
+
+  /// A event that's fired after framework finishes rendering the output
+  /// of [RenderElement.update] to the DOM.
+  ///
+  afterUpdateEffect,
+
+  /// A event that's fired when framework is about to remove the widget from
+  /// the DOM.
+  ///
+  beforeUnMountEffect,
+
+  /// A event that's fired after framework finishes removing the widget from
+  /// the DOM.
+  ///
+  afterUnMountEffect,
 }
 
 /// Type of DOM event.

--- a/packages/rad/lib/src/core/common/enums.dart
+++ b/packages/rad/lib/src/core/common/enums.dart
@@ -412,22 +412,22 @@ enum RenderEventType {
   /// A event that's fired after framework finishes rendering the output
   /// of [RenderElement.render] to the DOM.
   ///
-  afterRenderEffect,
+  didRender,
 
   /// A event that's fired after framework finishes rendering the output
   /// of [RenderElement.update] to the DOM.
   ///
-  afterUpdateEffect,
+  didUpdate,
 
   /// A event that's fired when framework is about to remove the widget from
   /// the DOM.
   ///
-  beforeUnMountEffect,
+  willUnMount,
 
   /// A event that's fired after framework finishes removing the widget from
   /// the DOM.
   ///
-  afterUnMountEffect,
+  didUnMount,
 }
 
 /// Type of DOM event.

--- a/packages/rad/lib/src/core/common/objects/render_event.dart
+++ b/packages/rad/lib/src/core/common/objects/render_event.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2022, Rad developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// A RenderElement's event.
+///
+/// Render events don't carry any information, they serves as mere signals
+/// for the listeners(for now).
+///
+class RenderEvent {
+  /// Create render event.
+  ///
+  const RenderEvent();
+}

--- a/packages/rad/lib/src/core/common/types.dart
+++ b/packages/rad/lib/src/core/common/types.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 import 'package:rad/src/core/common/abstract/build_context.dart';
 import 'package:rad/src/core/common/abstract/render_element.dart';
 import 'package:rad/src/core/common/enums.dart';
+import 'package:rad/src/core/common/objects/render_event.dart';
 import 'package:rad/src/core/services/events/emitted_event.dart';
 import 'package:rad/src/core/services/scheduler/abstract.dart';
 import 'package:rad/src/widgets/abstract/widget.dart';
@@ -20,6 +21,8 @@ typedef VoidCallback = void Function();
 typedef EventCallback = void Function(EmittedEvent event);
 
 typedef NativeEventCallback = void Function(Event event);
+
+typedef RenderEventCallback = void Function(RenderEvent event);
 
 typedef ExceptionCallback = void Function(Exception event);
 

--- a/packages/rad/lib/src/core/renderer/renderer.dart
+++ b/packages/rad/lib/src/core/renderer/renderer.dart
@@ -924,11 +924,13 @@ class Renderer with ServicesResolver {
     if (renderElement.frameworkChildElements.isNotEmpty) {
       var childElements = renderElement.frameworkEjectChildRenderElements();
 
-      for (final renderElement in childElements) {
-        disposeDetachedRenderElement(
-          renderElement: renderElement,
-          jobQueue: jobQueue,
-        );
+      if (renderElement.frameworkContainsUnMountListeners) {
+        for (final renderElement in childElements) {
+          disposeDetachedRenderElement(
+            renderElement: renderElement,
+            jobQueue: jobQueue,
+          );
+        }
       }
     }
 
@@ -965,11 +967,13 @@ class Renderer with ServicesResolver {
     required RenderElement renderElement,
     required JobQueue jobQueue,
   }) {
-    for (final childElement in renderElement.frameworkChildElements) {
-      disposeDetachedRenderElement(
-        renderElement: childElement,
-        jobQueue: jobQueue,
-      );
+    if (renderElement.frameworkContainsUnMountListeners) {
+      for (final childElement in renderElement.frameworkChildElements) {
+        disposeDetachedRenderElement(
+          renderElement: childElement,
+          jobQueue: jobQueue,
+        );
+      }
     }
 
     renderElement.frameworkDispatchRenderEvent(

--- a/packages/rad/lib/src/core/renderer/renderer.dart
+++ b/packages/rad/lib/src/core/renderer/renderer.dart
@@ -228,9 +228,9 @@ class Renderer with ServicesResolver {
       renderElement.frameworkBindDomNode(domNode: domNode);
     }
 
-    if (renderElement is WatchfulRenderElement) {
-      renderElement.frameworkInit();
+    renderElement.frameworkInitRenderElement();
 
+    if (renderElement is WatchfulRenderElement) {
       jobQueue.addPostDispatchCallback(renderElement.frameworkAfterMount);
     }
 

--- a/packages/rad/lib/src/core/renderer/renderer.dart
+++ b/packages/rad/lib/src/core/renderer/renderer.dart
@@ -8,7 +8,6 @@ import 'package:meta/meta.dart';
 
 import 'package:rad/src/core/common/abstract/build_context.dart';
 import 'package:rad/src/core/common/abstract/render_element.dart';
-import 'package:rad/src/core/common/abstract/watchful_render_element.dart';
 import 'package:rad/src/core/common/constants.dart';
 import 'package:rad/src/core/common/enums.dart';
 import 'package:rad/src/core/common/objects/common_render_elements.dart';
@@ -230,16 +229,26 @@ class Renderer with ServicesResolver {
 
     renderElement.frameworkInitRenderElement();
 
-    if (renderElement is WatchfulRenderElement) {
-      jobQueue.addPostDispatchCallback(renderElement.frameworkAfterMount);
-    }
+    // -----------------------------
 
     var domNodePatch = renderElement.frameworkRender(widget: widget);
     if (null != domNode && null != domNodePatch) {
       applyDomNodePatch(domNode: domNode, description: domNodePatch);
     }
 
-    // Register event listeners
+    if (renderElement.frameworkHasEventListenerOfType(
+      RenderEventType.afterRenderEffect,
+    )) {
+      jobQueue.addPostDispatchCallback(
+        () => renderElement.frameworkDispatchRenderEvent(
+          RenderEventType.afterRenderEffect,
+        ),
+      );
+    }
+
+    // -----------------------------
+
+    // Register DOM event listeners
 
     var bubbleEventListeners = widget.widgetEventListeners;
     var captureEventListeners = widget.widgetCaptureEventListeners;
@@ -557,9 +566,13 @@ class Renderer with ServicesResolver {
         });
       }
 
-      if (matchedRenderElement is WatchfulRenderElement) {
+      if (matchedRenderElement.frameworkHasEventListenerOfType(
+        RenderEventType.afterUpdateEffect,
+      )) {
         jobQueue.addPostDispatchCallback(
-          matchedRenderElement.frameworkAfterUpdate,
+          () => matchedRenderElement.frameworkDispatchRenderEvent(
+            RenderEventType.afterUpdateEffect,
+          ),
         );
       }
     } else {
@@ -818,9 +831,13 @@ class Renderer with ServicesResolver {
             });
           }
 
-          if (renderElement is WatchfulRenderElement) {
+          if (renderElement.frameworkHasEventListenerOfType(
+            RenderEventType.afterUpdateEffect,
+          )) {
             jobQueue.addPostDispatchCallback(
-              renderElement.frameworkAfterUpdate,
+              () => renderElement.frameworkDispatchRenderEvent(
+                RenderEventType.afterUpdateEffect,
+              ),
             );
           }
 
@@ -902,7 +919,7 @@ class Renderer with ServicesResolver {
       domNode?.remove();
     });
 
-    // Detach child elements and add a job to clean child elements
+    // Detach child elements
 
     if (renderElement.frameworkChildElements.isNotEmpty) {
       var childElements = renderElement.frameworkEjectChildRenderElements();
@@ -921,9 +938,18 @@ class Renderer with ServicesResolver {
 
     // Call lifecycle hooks
 
-    if (renderElement is WatchfulRenderElement) {
-      renderElement.frameworkDispose();
-      jobQueue.addPostDispatchCallback(renderElement.frameworkAfterUnMount);
+    renderElement.frameworkDispatchRenderEvent(
+      RenderEventType.beforeUnMountEffect,
+    );
+
+    if (renderElement.frameworkHasEventListenerOfType(
+      RenderEventType.afterUnMountEffect,
+    )) {
+      jobQueue.addPostDispatchCallback(
+        () => renderElement.frameworkDispatchRenderEvent(
+          RenderEventType.afterUnMountEffect,
+        ),
+      );
     }
 
     if (DEBUG_BUILD) {
@@ -946,9 +972,18 @@ class Renderer with ServicesResolver {
       );
     }
 
-    if (renderElement is WatchfulRenderElement) {
-      renderElement.frameworkDispose();
-      jobQueue.addPostDispatchCallback(renderElement.frameworkAfterUnMount);
+    renderElement.frameworkDispatchRenderEvent(
+      RenderEventType.beforeUnMountEffect,
+    );
+
+    if (renderElement.frameworkHasEventListenerOfType(
+      RenderEventType.afterUnMountEffect,
+    )) {
+      jobQueue.addPostDispatchCallback(
+        () => renderElement.frameworkDispatchRenderEvent(
+          RenderEventType.afterUnMountEffect,
+        ),
+      );
     }
 
     if (DEBUG_BUILD) {

--- a/packages/rad/lib/src/core/renderer/renderer.dart
+++ b/packages/rad/lib/src/core/renderer/renderer.dart
@@ -237,11 +237,11 @@ class Renderer with ServicesResolver {
     }
 
     if (renderElement.frameworkHasEventListenerOfType(
-      RenderEventType.afterRenderEffect,
+      RenderEventType.didRender,
     )) {
       jobQueue.addPostDispatchCallback(
         () => renderElement.frameworkDispatchRenderEvent(
-          RenderEventType.afterRenderEffect,
+          RenderEventType.didRender,
         ),
       );
     }
@@ -567,11 +567,11 @@ class Renderer with ServicesResolver {
       }
 
       if (matchedRenderElement.frameworkHasEventListenerOfType(
-        RenderEventType.afterUpdateEffect,
+        RenderEventType.didUpdate,
       )) {
         jobQueue.addPostDispatchCallback(
           () => matchedRenderElement.frameworkDispatchRenderEvent(
-            RenderEventType.afterUpdateEffect,
+            RenderEventType.didUpdate,
           ),
         );
       }
@@ -832,11 +832,11 @@ class Renderer with ServicesResolver {
           }
 
           if (renderElement.frameworkHasEventListenerOfType(
-            RenderEventType.afterUpdateEffect,
+            RenderEventType.didUpdate,
           )) {
             jobQueue.addPostDispatchCallback(
               () => renderElement.frameworkDispatchRenderEvent(
-                RenderEventType.afterUpdateEffect,
+                RenderEventType.didUpdate,
               ),
             );
           }
@@ -941,15 +941,15 @@ class Renderer with ServicesResolver {
     // Call lifecycle hooks
 
     renderElement.frameworkDispatchRenderEvent(
-      RenderEventType.beforeUnMountEffect,
+      RenderEventType.willUnMount,
     );
 
     if (renderElement.frameworkHasEventListenerOfType(
-      RenderEventType.afterUnMountEffect,
+      RenderEventType.didUnMount,
     )) {
       jobQueue.addPostDispatchCallback(
         () => renderElement.frameworkDispatchRenderEvent(
-          RenderEventType.afterUnMountEffect,
+          RenderEventType.didUnMount,
         ),
       );
     }
@@ -977,15 +977,15 @@ class Renderer with ServicesResolver {
     }
 
     renderElement.frameworkDispatchRenderEvent(
-      RenderEventType.beforeUnMountEffect,
+      RenderEventType.willUnMount,
     );
 
     if (renderElement.frameworkHasEventListenerOfType(
-      RenderEventType.afterUnMountEffect,
+      RenderEventType.didUnMount,
     )) {
       jobQueue.addPostDispatchCallback(
         () => renderElement.frameworkDispatchRenderEvent(
-          RenderEventType.afterUnMountEffect,
+          RenderEventType.didUnMount,
         ),
       );
     }

--- a/packages/rad/lib/src/core/renderer/renderer.dart
+++ b/packages/rad/lib/src/core/renderer/renderer.dart
@@ -349,13 +349,35 @@ class Renderer with ServicesResolver {
   }) {
     for (final updateObject in updates) {
       switch (updateObject.widgetUpdateType) {
-        case WidgetUpdateType.dispose:
-          updateObject as WidgetUpdateObjectActionDispose;
+        case WidgetUpdateType.addAllWithoutClean:
+          updateObject as WidgetUpdateObjectActionAddAllWithoutClean;
 
-          disposeWidget(
+          render(
+            mountAtIndex: null,
+            widgets: updateObject.widgets,
+            parentRenderElement: parentRenderElement,
+            flagCleanParentContents: false,
             jobQueue: jobQueue,
-            flagPreserveTarget: false,
-            renderElement: updateObject.existingElement,
+          );
+
+          break;
+
+        case WidgetUpdateType.update:
+          processWidgetUpdateObjectActionUpdate(
+            jobQueue: jobQueue,
+            updateType: updateType,
+            flagAddIfNotFound: flagAddIfNotFound,
+            updateObject: updateObject as WidgetUpdateObjectActionUpdate,
+          );
+
+          break;
+
+        case WidgetUpdateType.cleanParent:
+          updateObject as WidgetUpdateObjectActionCleanParent;
+
+          cleanRenderElement(
+            renderElement: parentRenderElement,
+            jobQueue: jobQueue,
           );
 
           break;
@@ -372,16 +394,6 @@ class Renderer with ServicesResolver {
               renderElement: renderElement,
             );
           }
-
-          break;
-
-        case WidgetUpdateType.cleanParent:
-          updateObject as WidgetUpdateObjectActionCleanParent;
-
-          cleanRenderElement(
-            renderElement: parentRenderElement,
-            jobQueue: jobQueue,
-          );
 
           break;
 
@@ -407,25 +419,13 @@ class Renderer with ServicesResolver {
 
           break;
 
-        case WidgetUpdateType.addAllWithoutClean:
-          updateObject as WidgetUpdateObjectActionAddAllWithoutClean;
+        case WidgetUpdateType.dispose:
+          updateObject as WidgetUpdateObjectActionDispose;
 
-          render(
-            mountAtIndex: null,
-            widgets: updateObject.widgets,
-            parentRenderElement: parentRenderElement,
-            flagCleanParentContents: false,
+          disposeWidget(
             jobQueue: jobQueue,
-          );
-
-          break;
-
-        case WidgetUpdateType.update:
-          processWidgetUpdateObjectActionUpdate(
-            jobQueue: jobQueue,
-            updateType: updateType,
-            flagAddIfNotFound: flagAddIfNotFound,
-            updateObject: updateObject as WidgetUpdateObjectActionUpdate,
+            flagPreserveTarget: false,
+            renderElement: updateObject.existingElement,
           );
 
           break;

--- a/packages/rad/test/fixtures/test_widget_render_able.dart
+++ b/packages/rad/test/fixtures/test_widget_render_able.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2022, Rad developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: camel_case_types
+
+import '../test_imports.dart';
+
+/// A RenderAble widget for testing base render element.
+///
+class RT_RenderAbleWidget extends Widget {
+  final VoidCallback? eventRegister;
+  final VoidCallback? eventRender;
+  final VoidCallback? eventUpdate;
+
+  final RenderEventCallback? eventAfterRenderEffect;
+  final RenderEventCallback? eventAfterUpdateEffect;
+  final RenderEventCallback? eventBeforeUnMountEffect;
+  final RenderEventCallback? eventAfterUnMountEffect;
+
+  final List<Widget>? children;
+
+  const RT_RenderAbleWidget({
+    Key? key,
+    this.eventRegister,
+    this.eventRender,
+    this.eventUpdate,
+    this.eventAfterRenderEffect,
+    this.eventAfterUpdateEffect,
+    this.eventBeforeUnMountEffect,
+    this.eventAfterUnMountEffect,
+    this.children,
+  }) : super(key: key);
+
+  @override
+  DomTagType? get correspondingTag => null;
+
+  @override
+  createRenderElement(parent) => _RenderAbleElement(this, parent);
+
+  @override
+  shouldUpdateWidget(oldWidget) => true;
+}
+
+class _RenderAbleElement extends RenderElement {
+  _RenderAbleElement(
+    RT_RenderAbleWidget widget,
+    RenderElement parent,
+  )   :
+        // prepare child widgets
+
+        _children = widget.children ?? const [],
+
+        // base
+
+        super(widget, parent);
+
+  @override
+  List<Widget> get widgetChildren => _children;
+  List<Widget> _children;
+
+  RT_RenderAbleWidget get currentWidget => widget as RT_RenderAbleWidget;
+
+  @override
+  void register() {
+    if (null != currentWidget.eventRegister) {
+      currentWidget.eventRegister!();
+    }
+
+    var eventListeners = <RenderEventType, RenderEventCallback>{};
+
+    var afterRenderEffect = currentWidget.eventAfterRenderEffect;
+    var afterUpdateEffect = currentWidget.eventAfterUpdateEffect;
+    var beforeUnMountEffect = currentWidget.eventBeforeUnMountEffect;
+    var afterUnMountEffect = currentWidget.eventAfterUnMountEffect;
+
+    if (null != afterRenderEffect) {
+      eventListeners[RenderEventType.afterRenderEffect] = afterRenderEffect;
+    }
+
+    if (null != afterUpdateEffect) {
+      eventListeners[RenderEventType.afterUpdateEffect] = afterUpdateEffect;
+    }
+
+    if (null != beforeUnMountEffect) {
+      eventListeners[RenderEventType.beforeUnMountEffect] = beforeUnMountEffect;
+    }
+
+    if (null != afterUnMountEffect) {
+      eventListeners[RenderEventType.afterUnMountEffect] = afterUnMountEffect;
+    }
+
+    addRenderEventListeners(eventListeners);
+  }
+
+  @override
+  render({required Widget widget}) {
+    var patch = super.render(widget: widget);
+
+    if (null != currentWidget.eventRender) {
+      currentWidget.eventRender!();
+    }
+
+    return patch;
+  }
+
+  @override
+  update({
+    required UpdateType updateType,
+    required Widget oldWidget,
+    required Widget newWidget,
+  }) {
+    var patch = super.update(
+      updateType: updateType,
+      oldWidget: oldWidget,
+      newWidget: newWidget,
+    );
+
+    if (null != currentWidget.eventUpdate) {
+      currentWidget.eventUpdate!();
+    }
+
+    return patch;
+  }
+
+  @override
+  afterWidgetRebind({
+    required oldWidget,
+    required covariant RT_RenderAbleWidget newWidget,
+    required updateType,
+  }) {
+    _children = newWidget.children ?? const [];
+  }
+}

--- a/packages/rad/test/fixtures/test_widget_render_able.dart
+++ b/packages/rad/test/fixtures/test_widget_render_able.dart
@@ -13,10 +13,10 @@ class RT_RenderAbleWidget extends Widget {
   final VoidCallback? eventRender;
   final VoidCallback? eventUpdate;
 
-  final RenderEventCallback? eventAfterRenderEffect;
-  final RenderEventCallback? eventAfterUpdateEffect;
-  final RenderEventCallback? eventBeforeUnMountEffect;
-  final RenderEventCallback? eventAfterUnMountEffect;
+  final RenderEventCallback? eventDidRender;
+  final RenderEventCallback? eventDidUpdate;
+  final RenderEventCallback? eventWillUnMount;
+  final RenderEventCallback? eventDidUnMount;
 
   final List<Widget>? children;
 
@@ -25,10 +25,10 @@ class RT_RenderAbleWidget extends Widget {
     this.eventRegister,
     this.eventRender,
     this.eventUpdate,
-    this.eventAfterRenderEffect,
-    this.eventAfterUpdateEffect,
-    this.eventBeforeUnMountEffect,
-    this.eventAfterUnMountEffect,
+    this.eventDidRender,
+    this.eventDidUpdate,
+    this.eventWillUnMount,
+    this.eventDidUnMount,
     this.children,
   }) : super(key: key);
 
@@ -69,25 +69,25 @@ class _RenderAbleElement extends RenderElement {
 
     var eventListeners = <RenderEventType, RenderEventCallback>{};
 
-    var afterRenderEffect = currentWidget.eventAfterRenderEffect;
-    var afterUpdateEffect = currentWidget.eventAfterUpdateEffect;
-    var beforeUnMountEffect = currentWidget.eventBeforeUnMountEffect;
-    var afterUnMountEffect = currentWidget.eventAfterUnMountEffect;
+    var afterRender = currentWidget.eventDidRender;
+    var afterUpdate = currentWidget.eventDidUpdate;
+    var beforeUnMount = currentWidget.eventWillUnMount;
+    var afterUnMount = currentWidget.eventDidUnMount;
 
-    if (null != afterRenderEffect) {
-      eventListeners[RenderEventType.afterRenderEffect] = afterRenderEffect;
+    if (null != afterRender) {
+      eventListeners[RenderEventType.didRender] = afterRender;
     }
 
-    if (null != afterUpdateEffect) {
-      eventListeners[RenderEventType.afterUpdateEffect] = afterUpdateEffect;
+    if (null != afterUpdate) {
+      eventListeners[RenderEventType.didUpdate] = afterUpdate;
     }
 
-    if (null != beforeUnMountEffect) {
-      eventListeners[RenderEventType.beforeUnMountEffect] = beforeUnMountEffect;
+    if (null != beforeUnMount) {
+      eventListeners[RenderEventType.willUnMount] = beforeUnMount;
     }
 
-    if (null != afterUnMountEffect) {
-      eventListeners[RenderEventType.afterUnMountEffect] = afterUnMountEffect;
+    if (null != afterUnMount) {
+      eventListeners[RenderEventType.didUnMount] = afterUnMount;
     }
 
     addRenderEventListeners(eventListeners);

--- a/packages/rad/test/test_imports.dart
+++ b/packages/rad/test/test_imports.dart
@@ -75,6 +75,7 @@ export 'fixtures/test_widget_stateful.dart';
 export 'fixtures/test_widget_eventful.dart';
 export 'fixtures/test_widget_stateless.dart';
 export 'fixtures/test_widget_inherited.dart';
+export 'fixtures/test_widget_render_able.dart';
 export 'fixtures/test_widget_watchful.dart';
 
 export 'mocks/test_window.dart';

--- a/packages/rad/test/tests/misc/render_element_events_test.dart
+++ b/packages/rad/test/tests/misc/render_element_events_test.dart
@@ -1,0 +1,295 @@
+// Copyright (c) 2022, Rad developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: prefer_function_declarations_over_variables
+
+import '../../test_imports.dart';
+
+void main() {
+  group('basic', () {
+    RT_AppRunner? app;
+
+    setUp(() {
+      app = createTestApp()..start();
+    });
+
+    tearDown(() => app!.stop());
+
+    test('should not add render event listeners by default', () async {
+      var pap = app!;
+
+      await pap.buildChildren(
+        widgets: [
+          RT_RenderAbleWidget(key: Key('widget')),
+        ],
+        parentRenderElement: pap.appRenderElement,
+      );
+      var renderElement = pap.renderElementByKeyValue('widget')!;
+      var eventListeners = renderElement.frameworkRenderEventListeners;
+
+      for (final renderEventType in RenderEventType.values) {
+        expect(eventListeners[renderEventType], equals(null));
+      }
+    });
+
+    test('should add event listeners ', () async {
+      var pap = app!;
+
+      var afterRender = (e) => {};
+      var afterUpdate = (e) => {};
+      var beforeUnMount = (e) => {};
+      var afterUnMount = (e) => {};
+
+      await pap.buildChildren(
+        widgets: [
+          RT_RenderAbleWidget(
+            key: Key('widget'),
+            eventAfterRenderEffect: afterRender,
+            eventAfterUpdateEffect: afterUpdate,
+            eventBeforeUnMountEffect: beforeUnMount,
+            eventAfterUnMountEffect: afterUnMount,
+          ),
+        ],
+        parentRenderElement: pap.appRenderElement,
+      );
+      var renderElement = pap.renderElementByKeyValue('widget')!;
+      var eventListeners = renderElement.frameworkRenderEventListeners;
+
+      expect(
+        eventListeners[RenderEventType.afterRenderEffect],
+        equals(afterRender),
+      );
+      expect(
+        eventListeners[RenderEventType.afterUpdateEffect],
+        equals(afterUpdate),
+      );
+      expect(
+        eventListeners[RenderEventType.afterUnMountEffect],
+        equals(afterUnMount),
+      );
+      expect(
+        eventListeners[RenderEventType.beforeUnMountEffect],
+        equals(beforeUnMount),
+      );
+    });
+  });
+
+  group('lifecycle', () {
+    test('should call register exactly once before render', () async {
+      var app = createTestApp()..start();
+      var stack = RT_TestStack();
+
+      await app.buildChildren(
+        widgets: [
+          RT_RenderAbleWidget(
+            eventRegister: () => stack.push('register'),
+            eventRender: () => stack.push('render'),
+          ),
+        ],
+        parentRenderElement: app.appRenderElement,
+      );
+
+      app.stop();
+      await Future.delayed(Duration(milliseconds: 100));
+
+      expect(stack.popFromStart(), equals('register'));
+      expect(stack.popFromStart(), equals('render'));
+      expect(stack.canPop(), equals(false));
+    });
+
+    test(
+      'should call render '
+      ', exactly once '
+      ', after register '
+      ', before afterRender ',
+      () async {
+        var app = createTestApp()..start();
+        var stack = RT_TestStack();
+
+        await app.buildChildren(
+          widgets: [
+            RT_RenderAbleWidget(
+              eventRegister: () => stack.push('register'),
+              eventRender: () => stack.push('render'),
+              eventAfterRenderEffect: (e) => stack.push('after render'),
+            ),
+          ],
+          parentRenderElement: app.appRenderElement,
+        );
+
+        await app.updateChildren(
+          widgets: [
+            RT_RenderAbleWidget(
+              eventRegister: () => stack.push('register'),
+              eventRender: () => stack.push('render'),
+              eventAfterRenderEffect: (e) => stack.push('after render'),
+            ),
+          ],
+          updateType: UpdateType.setState,
+          parentRenderElement: app.appRenderElement,
+        );
+
+        app.stop();
+        await Future.delayed(Duration(milliseconds: 100));
+
+        expect(stack.popFromStart(), equals('register'));
+        expect(stack.popFromStart(), equals('render'));
+        expect(stack.popFromStart(), equals('after render'));
+        expect(stack.canPop(), equals(false));
+      },
+    );
+
+    test('should call update after render', () async {
+      var app = createTestApp()..start();
+      var stack = RT_TestStack();
+
+      await app.buildChildren(
+        widgets: [
+          RT_RenderAbleWidget(
+            children: [Text('hello world')],
+            eventRender: () => stack.push('render'),
+            eventUpdate: () => stack.push('update'),
+          ),
+        ],
+        parentRenderElement: app.appRenderElement,
+      );
+
+      await app.updateChildren(
+        widgets: [
+          RT_RenderAbleWidget(
+            children: [Text('hello world')],
+            eventRender: () => stack.push('render'),
+            eventUpdate: () => stack.push('update'),
+          ),
+        ],
+        updateType: UpdateType.setState,
+        parentRenderElement: app.appRenderElement,
+      );
+
+      app.stop();
+      await Future.delayed(Duration(milliseconds: 100));
+
+      expect(stack.popFromStart(), equals('render'));
+      expect(stack.popFromStart(), equals('update'));
+      expect(stack.canPop(), equals(false));
+    });
+
+    test('should call beforeUnMount before actual un-mount', () async {
+      var stack = RT_TestStack();
+
+      var runner = runApp(
+        app: RT_RenderAbleWidget(
+          children: [Text('hello world')],
+          eventBeforeUnMountEffect: (e) {
+            stack.push('before un-mount');
+            expect(RT_TestBed.rootDomNode, RT_hasContents('hello world'));
+          },
+        ),
+        appTargetId: RT_TestBed.rootTargetId,
+      );
+
+      await Future.delayed(Duration(milliseconds: 100));
+      runner.stop();
+      await Future.delayed(Duration(milliseconds: 100));
+
+      expect(stack.popFromStart(), equals('before un-mount'));
+      expect(stack.canPop(), equals(false));
+    });
+
+    test(
+      'should call afterRender '
+      ', exactly once '
+      ', after render ',
+      () async {
+        var app = createTestApp()..start();
+        var stack = RT_TestStack();
+
+        await app.buildChildren(
+          widgets: [
+            RT_RenderAbleWidget(
+              children: [Text('hello world')],
+              eventRender: () => stack.push('render'),
+              eventAfterRenderEffect: (e) {
+                stack.push('after render');
+
+                expect(app.appDomNode, RT_hasContents('hello world'));
+              },
+            ),
+          ],
+          parentRenderElement: app.appRenderElement,
+        );
+
+        app.stop();
+        await Future.delayed(Duration(milliseconds: 100));
+
+        expect(stack.popFromStart(), equals('render'));
+        expect(stack.popFromStart(), equals('after render'));
+        expect(stack.canPop(), equals(false));
+      },
+    );
+
+    test('should call afterUpdate after dom updates', () async {
+      var app = createTestApp()..start();
+      var stack = RT_TestStack();
+
+      await app.buildChildren(
+        widgets: [
+          RT_RenderAbleWidget(
+            children: [Text('initial contents')],
+            eventUpdate: () => stack.push('update'),
+            eventAfterUpdateEffect: (e) {
+              stack.push('after update');
+              expect(app.appDomNode, RT_hasContents('updated contents'));
+            },
+          ),
+        ],
+        parentRenderElement: app.appRenderElement,
+      );
+
+      await app.updateChildren(
+        widgets: [
+          RT_RenderAbleWidget(
+            children: [Text('updated contents')],
+            eventUpdate: () => stack.push('update'),
+            eventAfterUpdateEffect: (e) {
+              stack.push('after update');
+              expect(app.appDomNode, RT_hasContents('updated contents'));
+            },
+          ),
+        ],
+        updateType: UpdateType.setState,
+        parentRenderElement: app.appRenderElement,
+      );
+
+      app.stop();
+      await Future.delayed(Duration(milliseconds: 100));
+
+      expect(stack.popFromStart(), equals('update'));
+      expect(stack.popFromStart(), equals('after update'));
+      expect(stack.canPop(), equals(false));
+    });
+
+    test('should call afterUnMount after actual un-mount', () async {
+      var stack = RT_TestStack();
+
+      var runner = runApp(
+        app: RT_RenderAbleWidget(
+          children: [Text('hello world')],
+          eventAfterUnMountEffect: (e) {
+            stack.push('after unmount');
+            expect(RT_TestBed.rootDomNode, RT_hasContents(''));
+          },
+        ),
+        appTargetId: RT_TestBed.rootTargetId,
+      );
+
+      await Future.delayed(Duration(milliseconds: 100));
+      runner.stop();
+      await Future.delayed(Duration(milliseconds: 100));
+
+      expect(stack.popFromStart(), equals('after unmount'));
+      expect(stack.canPop(), equals(false));
+    });
+  });
+}

--- a/packages/rad/test/tests/misc/render_element_events_test.dart
+++ b/packages/rad/test/tests/misc/render_element_events_test.dart
@@ -36,19 +36,19 @@ void main() {
     test('should add event listeners ', () async {
       var pap = app!;
 
-      var afterRender = (e) => {};
-      var afterUpdate = (e) => {};
-      var beforeUnMount = (e) => {};
-      var afterUnMount = (e) => {};
+      var didRender = (e) => {};
+      var didUpdate = (e) => {};
+      var willUnMount = (e) => {};
+      var didUnMount = (e) => {};
 
       await pap.buildChildren(
         widgets: [
           RT_RenderAbleWidget(
             key: Key('widget'),
-            eventAfterRenderEffect: afterRender,
-            eventAfterUpdateEffect: afterUpdate,
-            eventBeforeUnMountEffect: beforeUnMount,
-            eventAfterUnMountEffect: afterUnMount,
+            eventDidRender: didRender,
+            eventDidUpdate: didUpdate,
+            eventWillUnMount: willUnMount,
+            eventDidUnMount: didUnMount,
           ),
         ],
         parentRenderElement: pap.appRenderElement,
@@ -57,20 +57,20 @@ void main() {
       var eventListeners = renderElement.frameworkRenderEventListeners;
 
       expect(
-        eventListeners[RenderEventType.afterRenderEffect],
-        equals(afterRender),
+        eventListeners[RenderEventType.didRender],
+        equals(didRender),
       );
       expect(
-        eventListeners[RenderEventType.afterUpdateEffect],
-        equals(afterUpdate),
+        eventListeners[RenderEventType.didUpdate],
+        equals(didUpdate),
       );
       expect(
-        eventListeners[RenderEventType.afterUnMountEffect],
-        equals(afterUnMount),
+        eventListeners[RenderEventType.didUnMount],
+        equals(didUnMount),
       );
       expect(
-        eventListeners[RenderEventType.beforeUnMountEffect],
-        equals(beforeUnMount),
+        eventListeners[RenderEventType.willUnMount],
+        equals(willUnMount),
       );
     });
   });
@@ -102,7 +102,7 @@ void main() {
       'should call render '
       ', exactly once '
       ', after register '
-      ', before afterRender ',
+      ', before didRender ',
       () async {
         var app = createTestApp()..start();
         var stack = RT_TestStack();
@@ -112,7 +112,7 @@ void main() {
             RT_RenderAbleWidget(
               eventRegister: () => stack.push('register'),
               eventRender: () => stack.push('render'),
-              eventAfterRenderEffect: (e) => stack.push('after render'),
+              eventDidRender: (e) => stack.push('after render'),
             ),
           ],
           parentRenderElement: app.appRenderElement,
@@ -123,7 +123,7 @@ void main() {
             RT_RenderAbleWidget(
               eventRegister: () => stack.push('register'),
               eventRender: () => stack.push('render'),
-              eventAfterRenderEffect: (e) => stack.push('after render'),
+              eventDidRender: (e) => stack.push('after render'),
             ),
           ],
           updateType: UpdateType.setState,
@@ -175,13 +175,13 @@ void main() {
       expect(stack.canPop(), equals(false));
     });
 
-    test('should call beforeUnMount before actual un-mount', () async {
+    test('should call willUnMount before actual un-mount', () async {
       var stack = RT_TestStack();
 
       var runner = runApp(
         app: RT_RenderAbleWidget(
           children: [Text('hello world')],
-          eventBeforeUnMountEffect: (e) {
+          eventWillUnMount: (e) {
             stack.push('before un-mount');
             expect(RT_TestBed.rootDomNode, RT_hasContents('hello world'));
           },
@@ -198,7 +198,7 @@ void main() {
     });
 
     test(
-      'should call afterRender '
+      'should call didRender '
       ', exactly once '
       ', after render ',
       () async {
@@ -210,7 +210,7 @@ void main() {
             RT_RenderAbleWidget(
               children: [Text('hello world')],
               eventRender: () => stack.push('render'),
-              eventAfterRenderEffect: (e) {
+              eventDidRender: (e) {
                 stack.push('after render');
 
                 expect(app.appDomNode, RT_hasContents('hello world'));
@@ -229,7 +229,7 @@ void main() {
       },
     );
 
-    test('should call afterUpdate after dom updates', () async {
+    test('should call didUpdate after dom updates', () async {
       var app = createTestApp()..start();
       var stack = RT_TestStack();
 
@@ -238,7 +238,7 @@ void main() {
           RT_RenderAbleWidget(
             children: [Text('initial contents')],
             eventUpdate: () => stack.push('update'),
-            eventAfterUpdateEffect: (e) {
+            eventDidUpdate: (e) {
               stack.push('after update');
               expect(app.appDomNode, RT_hasContents('updated contents'));
             },
@@ -252,7 +252,7 @@ void main() {
           RT_RenderAbleWidget(
             children: [Text('updated contents')],
             eventUpdate: () => stack.push('update'),
-            eventAfterUpdateEffect: (e) {
+            eventDidUpdate: (e) {
               stack.push('after update');
               expect(app.appDomNode, RT_hasContents('updated contents'));
             },
@@ -270,13 +270,13 @@ void main() {
       expect(stack.canPop(), equals(false));
     });
 
-    test('should call afterUnMount after actual un-mount', () async {
+    test('should call didUnMount after actual un-mount', () async {
       var stack = RT_TestStack();
 
       var runner = runApp(
         app: RT_RenderAbleWidget(
           children: [Text('hello world')],
-          eventAfterUnMountEffect: (e) {
+          eventDidUnMount: (e) {
             stack.push('after unmount');
             expect(RT_TestBed.rootDomNode, RT_hasContents(''));
           },


### PR DESCRIPTION
This pull request contains:

1. **RenderEvents**, *a event system for RenderElements*.
2. Couple of optimizations, major one being the ability to short-circuit dispose(s) using RenderEvents.

### Render events

RenderEvents are the events that framework will emit when it interacts with a RenderElement. Just like we can add event listeners for user interactions on DOM elements, we can now add event listeners for framework interactions on RenderElements. Similar to DOM events, we've different types of RenderEvents for different types of interactions which are listed below:

- `afterRenderEffect` is a event that's emitted after framework finishes rendering the output of [render](https://pub.dev/documentation/rad/latest/rad/RenderElement/render.html) to the DOM.
- `afterUpdateEffect` is a event that's emitted after framework finishes rendering the output of [update](https://pub.dev/documentation/rad/latest/rad/RenderElement/update.html) to the DOM.
- `beforeUnMountEffect` is a event that's emitted when framework is about to remove the widget from the DOM.
- `afterUnMountEffect` is a event that's emitted after framework finishes removing the widget from the DOM.

RenderElements can decide to listen to a particular or all render events by adding event listeners. 

Comparing RenderEvents with DOM events, there are few differences & restrictions:

- RenderEvents do not have capture/bubble phase.
- RenderEvents are meant to be listened internally inside RenderElements.
- Listeners for RenderEvents can be attached only during initial render, and cannot be updated.

These restrictions are temporary and we'll lift them when needed. 

RenderEvents are meant to solve the problem of limited control over lifecycle in RenderElements. Previously we were providing a sub-class `WatchfulRenderElement` with hardcoded lifecycle. Now, using the new RenderEvents API, users can add as much or as little lifecycle as they want, to any RenderElement(widget). This new API effectively makes `WatchfulRenderElement` obsolete(but we'll keep it for backward compatibility).

### Benchmark results

- [RenderEvents (*prototype*) vs 1.1.0 (1)](https://erlage.github.io/pr-results/hash-19/v1.1.0-01/index.html)
- [RenderEvents (*prototype*) vs 1.1.0 (2)](https://erlage.github.io/pr-results/hash-19/v1.1.0-02/index.html)
- [RenderEvents (*prototype*) vs 1.1.0 (3)](https://erlage.github.io/pr-results/hash-19/v1.1.0-03/index.html)
- [RenderEvents (*prototype*) vs RenderEvents (*final*) (1)](https://erlage.github.io/pr-results/hash-19/v1.1.0-04/index.html)
- [RenderEvents (*prototype*) vs RenderEvents (*final*) (2)](https://erlage.github.io/pr-results/hash-19/v1.1.0-05/index.html)